### PR TITLE
Remove quotes from image repository and tag in deployment template

### DIFF
--- a/gcpFilestoreBackups/templates/deployment.yaml
+++ b/gcpFilestoreBackups/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       automountServiceAccountToken: False
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           command:
             - python
             - gcp-filestore-backups.py


### PR DESCRIPTION
I'm thinking this is what is causing validation to fail in 2i2c/infrastructure repo