### PR TITLE
Remove support for backing up multiple filestores

### DIFF
--- a/gcpFilestoreBackups/templates/deployment.yaml
+++ b/gcpFilestoreBackups/templates/deployment.yaml
@@ -31,17 +31,11 @@ spec:
             - python
             - gcp-filestore-backups.py
           args:
-            {{- range .Values.filestoreNames | required "filestoreNames is required" }}
-            - '{{ . }}'
-            {{- end }}
-            - --project {{ .Values.project | required "project is required" }}
-            - --zone {{ .Values.zone | required "zone is required" }}
-            {{- if .Values.retentionDays }}
-            - --retention-days {{ .Values.retentionDays }}
-            {{- end }}
-            {{- if .Values.backupFreqDays }}
-            - --backup-freq-days {{ .Values.backupFreqDays }}
-            {{- end }}
+            - --filestore-name={{ .Values.filestoreName | required "filestoreName is required" }}
+            - --project={{ .Values.project | required "project is required" }}
+            - --zone={{ .Values.zone | required "zone is required" }}
+            - --retention-days-={{ .Values.retentionDays }}
+            - --backup-freq-days={{ .Values.backupFreqDays }}
           securityContext:
             runAsUser: 1000
             allowPrivilegeEscalation: False

--- a/gcpFilestoreBackups/values.schema.yaml
+++ b/gcpFilestoreBackups/values.schema.yaml
@@ -70,18 +70,18 @@ properties:
     type: [string, "null"]
     description: |
       See documentation under [`fullnameOverride`](schema_fullnameOverride).
-  filestoreNames:
-    type: array
+  filestoreName:
+    type: string
     description: |
-      The name of one or more GCP FileStore instances to backup
+      The name of the GCP Filestore instances to backup
   project:
     type: string
     description: |
-      The GCP project the FileStore and backups are stored in
+      The GCP project the Filestore and backups are stored in
   zone:
     type: string
     description: |
-      The GCP zone the FileStore and backups are stored in, e.g., us-central1-b
+      The GCP zone the Filestore and backups are stored in, e.g., us-central1-b
   serviceAccount:
     type: object
     additionalProperties: false
@@ -106,11 +106,11 @@ properties:
   retentionDays:
     type: integer
     description: |
-      The number of days to retain backups for
+      The number of days to retain backups for. Default is 5 days.
   backupFreqDays:
     type: integer
     description: |
-      How frequently, in days, a backup should be made
+      How frequently, in days, a backup should be made. Default is daily (1).
   image:
     type: object
     additionalProperties: false

--- a/gcpFilestoreBackups/values.yaml
+++ b/gcpFilestoreBackups/values.yaml
@@ -9,7 +9,7 @@ nameOverride:
 enabled:
 
 # Required values for the chart
-filestoreNames: []
+filestoreName: blah
 project: blah
 zone: blah
 
@@ -23,8 +23,8 @@ serviceAccount:
   # Annotations to add to the service account
   annotations: {}
 
-retentionDays:
-backupFreqDays:
+retentionDays: 5
+backupFreqDays: 1
 
 # Other config for managing the deployment
 podLabels: {}

--- a/images/gcp-filestore-backups/gcp-filestore-backups.py
+++ b/images/gcp-filestore-backups/gcp-filestore-backups.py
@@ -200,24 +200,23 @@ def delete_old_backups(backups: list, region: str):
 def main(args):
     region = extract_region_from_zone(args.zone)
 
-    for filestore_name in args.filestore_names:
-        filestore_backups = get_existing_backups(
-            args.project, region, filestore_name, args.filestore_share_name
+    filestore_backups = get_existing_backups(
+        args.project, region, args.filestore_name, args.filestore_share_name
+    )
+    recent_filestore_backups, old_filestore_backups = (
+        filter_backups_into_recent_and_old(
+            filestore_backups, args.retention_days, args.backup_freq_days
         )
-        recent_filestore_backups, old_filestore_backups = (
-            filter_backups_into_recent_and_old(
-                filestore_backups, args.retention_days, args.backup_freq_days
-            )
-        )
-        create_backup_if_necessary(
-            recent_filestore_backups,
-            filestore_name,
-            args.filestore_share_name,
-            args.project,
-            region,
-            args.zone,
-        )
-        delete_old_backups(old_filestore_backups, region)
+    )
+    create_backup_if_necessary(
+        recent_filestore_backups,
+        args.filestore_name,
+        args.filestore_share_name,
+        args.project,
+        region,
+        args.zone,
+    )
+    delete_old_backups(old_filestore_backups, region)
 
 
 if __name__ == "__main__":
@@ -231,9 +230,9 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "filestore_names",
-        nargs="+",
-        help="The name of one or more GCP Filestores to backup",
+        "--filestore-name",
+        type=str,
+        help="The name of the GCP Filestore to backup",
     )
     parser.add_argument(
         "--project",
@@ -247,7 +246,7 @@ if __name__ == "__main__":
     )
 
     # NOTE: We assume that the share name will be homes on all GCP filestores
-    #       right now.
+    #       right now. This argument is not currently exposed via the helm chart.
     parser.add_argument(
         "--filestore-share-name",
         type=str,
@@ -257,14 +256,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--retention-days",
         type=int,
-        default=5,
-        help="The number of days to store backups for. Default: 5 days.",
+        help="The number of days to store backups for",
     )
     parser.add_argument(
-        "--back-freq-days",
+        "--backup-freq-days",
         type=int,
-        default=1,
-        help="How regularly, in days, backups are made. Default: 1 day.",
+        help="How regularly, in days, backups are made",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
The helm templating was a bit too complex and the input arguments to the python script were getting mangled. So I simplified this to supporting only a single Filestore.